### PR TITLE
refactor: Use exact commit SHAs for KSU-Next and SUSFS in build summary

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -49,11 +49,51 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        echo "::group::Validate inputs"
         model='${{ inputs.model }}'
-        if [[ -z "$model" ]]; then
-          echo "Empty model not allowed"; exit 1
+        soc='${{ inputs.soc }}'
+        branch='${{ inputs.branch }}'
+        manifest='${{ inputs.manifest }}'
+        optimize='${{ inputs.optimize_level }}'
+    
+        # Non-empty checks
+        [[ -n "$model" ]] || { echo "Input 'model' cannot be empty"; exit 1; }
+        [[ -n "$soc" ]] || { echo "Input 'soc' cannot be empty"; exit 1; }
+        [[ -n "$branch" ]] || { echo "Input 'branch' cannot be empty"; exit 1; }
+        [[ -n "$manifest" ]] || { echo "Input 'manifest' cannot be empty"; exit 1; }
+    
+        # Basic format checks
+        # soc: allow letters, digits, underscores, dashes (e.g., sm8650)
+        if ! [[ "$soc" =~ ^[A-Za-z0-9_-]+$ ]]; then
+          echo "Input 'soc' contains invalid characters. Allowed: letters, digits, underscore, dash"; exit 1
+        fi    
+        # branch: allow common ref patterns; spaces not allowed
+        if ! [[ "$branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+          echo "Input 'branch' contains invalid characters. Allowed: letters, digits, ., _, -, /"; exit 1
+        fi    
+        # manifest: either HTTPS URL ending with .xml, or a filename ending with .xml (no spaces)
+        if [[ "$manifest" == http*://* ]]; then
+          if ! [[ "$manifest" =~ ^https:// ]]; then
+            echo "Manifest URL must be HTTPS"; exit 1
+          fi
+          if ! [[ "$manifest" =~ \.xml($|\?) ]]; then
+            echo "Manifest URL should point to an XML file (.xml)"; exit 1
+          fi
+        else
+          if ! [[ "$manifest" =~ \.xml$ ]]; then
+            echo "Manifest filename must end with .xml"; exit 1
+          fi
+          if [[ "$manifest" =~ [[:space:]] ]]; then
+            echo "Manifest filename cannot contain spaces"; exit 1
+          fi
         fi
+        # Optimize level validation
+        case "$optimize" in
+          O2|O3) ;;
+          *) echo "optimize_level must be O2 or O3; got '$optimize'"; exit 1 ;;
+        esac
         echo "Input validation OK."
+        echo "::endgroup::"
 
     - name: Install Minimal Dependencies
       shell: bash
@@ -178,6 +218,8 @@ runs:
         cd susfs4ksu
         if git rev-parse --verify "origin/$SUSFS_BRANCH" >/dev/null 2>&1 || git rev-parse --verify "$SUSFS_BRANCH" >/dev/null 2>&1; then
           git checkout "$SUSFS_BRANCH"
+          SUSFS_COMMIT_SHA=$(git rev-parse HEAD)
+          echo "SUSFS_COMMIT_SHA=$SUSFS_COMMIT_SHA" >> $GITHUB_ENV
         else
           echo "Error: SUSFS branch or ref '$SUSFS_BRANCH' not found."
           exit 1
@@ -214,6 +256,10 @@ runs:
           curl --fail --location --proto '=https' -LSs "https://raw.githubusercontent.com/KernelSU-Next/KernelSU-Next/next/kernel/setup.sh" | bash -s "${{ inputs.ksun_branch }}"
         fi
         git submodule update --init --recursive
+        cd KernelSU-Next
+        KSUN_COMMIT_SHA=$(git rev-parse HEAD)
+        echo "KSUN_COMMIT_SHA=$KSUN_COMMIT_SHA" >> $GITHUB_ENV
+        cd ..
 
     - name: Apply SUSFS Patches
       shell: bash
@@ -251,7 +297,7 @@ runs:
             cp "../../../kernel_patches/next/susfs_fix_patches/$susfs_version/fix_ksud.c.patch" ./
             patch -p1 --forward --fuzz=3 < fix_ksud.c.patch
             ;;
-          "v1.5.9"|"v1.5.10"|"v1.5.11")
+          "v1.5.9"|"v1.5.10"|"v1.5.11"|"v1.5.12")
             cp ../../../susfs4ksu/kernel_patches/KernelSU/10_enable_susfs_for_ksu.patch ./
             patch -p1 --forward < 10_enable_susfs_for_ksu.patch  || true
             for file in $(find ./kernel -maxdepth 2 -name "*.rej" -printf "%f\n" | cut -d'.' -f1); do
@@ -281,7 +327,7 @@ runs:
         else
           echo "Kernel >= $MIN_VERSION, skipping ptrace patch"
         fi
-        if [ "${{ inputs.model }}" == "OPAce5Pro" ] || [ "${{ inputs.model }}" == "OP13-CN" || [ "${{ inputs.model }}" == "OP13-GLO" ]; then
+        if [ "${{ inputs.model }}" == "OPAce5Pro" ] || [ "${{ inputs.model }}" == "OP13-CN" ] || [ "${{ inputs.model }}" == "OP13-GLO" ]; then
           echo "Patching hmbird!"
           echo 'obj-y += hmbird_patch.o' >> ./drivers/Makefile
           patch -p1 -F 3 < "../../../kernel_patches/oneplus/hmbird/hmbird_kernel_patch.patch"
@@ -299,6 +345,15 @@ runs:
         set -euo pipefail
         cd "$CONFIG/kernel_platform/common"
         patch -p1 < ../../../kernel_patches/next/scope_min_manual_hooks_v1.4.patch
+
+    - name: Apply xx_maps patch (untill sus_maps is released)
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "$CONFIG/kernel_platform/common"
+        patch -p1 --forward < "../../../kernel_patches/maps/xx_maps_sus_kernel.patch"
+        cd "../KernelSU-Next"
+        patch -p1 --forward < "../../../kernel_patches/maps/xx_maps_ksu.patch"
 
     - name: Add KernelSU-Next and SUSFS Configuration Settings
       shell: bash
@@ -414,12 +469,19 @@ runs:
 
     - name: Build Kernel
       shell: bash
+      env:
+        PYTHONWARNINGS: "ignore:invalid escape sequence"
       run: |
         set -euo pipefail
+        echo "::group::Build kernel"
         KERNEL_PATH="$GITHUB_WORKSPACE/$CONFIG/kernel_platform"
         COMMON="$KERNEL_PATH/common"
         cd "$COMMON"
         : > "$COMMON/.scmversion"
+        
+        # Ensure Python warnings are suppressed for scripts invoked by make
+        export PYTHONWARNINGS="${PYTHONWARNINGS}"
+        
         if [ -n "${CLANG_BIN_PATH:-}" ] && [ -x "${CLANG_BIN_PATH}/clang" ]; then
           export PATH="${CLANG_BIN_PATH}:$PATH"
         fi
@@ -432,30 +494,43 @@ runs:
         OUT=out
         mkdir -p "$OUT"
         make O="$OUT" gki_defconfig
+        
+        # LOCALVERSION branding
         if [ -n "${CUSTOM_LOCALVERSION:-}" ]; then
           scripts/config --file "$OUT/.config" --set-str LOCALVERSION "${CUSTOM_LOCALVERSION}"
           scripts/config --file "$OUT/.config" -d LOCALVERSION_AUTO || true
           sed -i 's/scm_version="$(scm_version --short)"/scm_version=""/' scripts/setlocalversion
         fi
+        
+        # Optimize level config and flags
         if [ "${{ inputs.optimize_level }}" = "O3" ]; then
           scripts/config --file "$OUT/.config" -d CC_OPTIMIZE_FOR_PERFORMANCE
           scripts/config --file "$OUT/.config" -e CC_OPTIMIZE_FOR_PERFORMANCE_O3
-          export KCFLAGS="-Wno-error -pipe -O3 -fno-stack-protector"
+          KCFLAGS_EXTRA="-O3"
         else
           scripts/config --file "$OUT/.config" -e CC_OPTIMIZE_FOR_PERFORMANCE
           scripts/config --file "$OUT/.config" -d CC_OPTIMIZE_FOR_PERFORMANCE_O3
-          export KCFLAGS="-Wno-error -pipe -O2 -fno-stack-protector"
+          KCFLAGS_EXTRA="-O2"
         fi
-        export KCPPFLAGS="-DCONFIG_OPTIMIZE_INLINING"
+        
+        # Consistent flags; include -pipe and disable stack protector
+        KCFLAGS="-Wno-error -pipe -fno-stack-protector ${KCFLAGS_EXTRA}"
+        KCPPFLAGS="-DCONFIG_OPTIMIZE_INLINING"
+        
+        # Regenerate defaults after config edits
         make O="$OUT" olddefconfig
+        
         echo "Starting build with $(nproc --all) threads..."
         set -o pipefail
-        make -j"$(nproc --all)" O="$OUT" 2>&1 | tee build.log
+        make -j"$(nproc --all)" O="$OUT" KCFLAGS="$KCFLAGS" KCPPFLAGS="$KCPPFLAGS" 2>&1 | tee build.log
+        
         IMG="$OUT/arch/arm64/boot/Image"
         if [ ! -f "$IMG" ]; then
-          echo "Kernel Image missing"; exit 1
+          echo "Kernel Image missing"
+          exit 1
         fi
         sha256sum "$IMG" | tee "$OUT/Image.sha256"
+        echo "::endgroup::"
 
     - name: Collect Build Stats / Validate Image
       id: collect_stats
@@ -504,7 +579,7 @@ runs:
         cd "$GITHUB_WORKSPACE/AnyKernel3"
     
         # Optional hmbird patch logic
-        if [ "${{ inputs.model }}" == "OPAce5Pro" ] || [ "${{ inputs.model }}" == "OP13-CN" || [ "${{ inputs.model }}" == "OP13-GLO" ]; then
+        if [ "${{ inputs.model }}" == "OPAce5Pro" ] || [ "${{ inputs.model }}" == "OP13-CN" ] || [ "${{ inputs.model }}" == "OP13-GLO" ]; then
           cp "$GITHUB_WORKSPACE/kernel_patches/oneplus/hmbird/bins/"* ./tools/ 2>/dev/null || true
           patch -F 3 < "$GITHUB_WORKSPACE/kernel_patches/oneplus/hmbird/ak3_hmbird_patch.patch"
         fi
@@ -532,8 +607,10 @@ runs:
           echo "Kernel base: ${{ env.KERNEL_VER }}"
           echo "Kernel full: ${{ env.KERNEL_FULL_VER }}"
           echo "Kernel Uname: ${{ env.KERNEL_UNAME }}"
-          echo "KSU Version: ${KSUVER:-unknown}"
+          echo "KSUN Version: ${KSUVER:-unknown}"
+          echo "KSUN commit SHA: ${{ env.KSUN_COMMIT_SHA }}"
           echo "SUSFS Version: ${SUSVER:-unknown}"
+          echo "SUSFS commit SHA: ${{ env.SUSFS_COMMIT_SHA }}"
           echo "Optimization: ${{ inputs.optimize_level }}"
           echo "Image SHA256: ${{ steps.collect_stats.outputs.image_sha256 }}"
           echo "Compiler: ${CLANG_VERSION:-unknown}"
@@ -546,8 +623,10 @@ runs:
           echo "- Android: ${{ env.ANDROID_VER }}"
           echo "- Kernel Version: ${{ steps.save_metadata.outputs.kernel_version }}"
           echo "- Kernel Uname: ${{ env.KERNEL_UNAME }}"
-          echo "- KSU Version: ${KSUVER:-unknown}"
+          echo "- KSUN Version: ${KSUVER:-unknown}"
+          echo "- KSUN commit SHA: [${{ env.KSUN_COMMIT_SHA }}](https://github.com/KernelSU-Next/KernelSU-Next/commit/${{ env.KSUN_COMMIT_SHA }})"
           echo "- SUSFS Version: ${SUSVER:-unknown}"
+          echo "- SUSFS commit SHA: [${{ env.SUSFS_COMMIT_SHA }}](https://gitlab.com/simonpunk/susfs4ksu/-/commit/${{ env.SUSFS_COMMIT_SHA }})"
           echo "- Optimization: ${{ inputs.optimize_level }}"
           echo "- Image SHA256: ${{ steps.collect_stats.outputs.image_sha256 }}"
           echo "- Warnings Count: ${{ steps.collect_stats.outputs.warnings_count }}"

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -21,9 +21,7 @@ on:
         description: "Compiler optimization level"
         required: true
         type: choice
-        options:
-          - O2
-          - O3
+        options: [O2, O3]
         default: O2
       android12-5_10_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android12-5.10'
@@ -51,94 +49,194 @@ on:
         default: ''
 
 jobs:
-  build-batch-1:
-    name: build-batch-1 (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+  build:
+    name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+    
+    runs-on: [self-hosted, ubuntu-24.04]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - model: OP11
-            soc: kalama
-            branch: oneplus/sm8550
-            manifest: oneplus_11_v.xml
-            android_version: android13
-            kernel_version: '5.15'
-          - model: OP13-CN
-            soc: sun
-            branch: oneplus/sm8750
-            manifest: oneplus_13.xml
-            android_version: android15
-            kernel_version: '6.6'
-          - model: OP13-GLO
-            soc: sun
-            branch: oneplus/sm8750
-            manifest: oneplus_13_global.xml
-            android_version: android15
-            kernel_version: '6.6'
-#          - model: OPAce5Pro
-#            soc: sun
-#            branch: oneplus/sm8750
-#            manifest: oneplus_ace5_pro.xml
-#            android_version: android15
-#            kernel_version: '6.6'
-          - model: OP13S
-            soc: sun
-            branch: oneplus/sm8750
-            manifest: oneplus_13s.xml
-            android_version: android15
-            kernel_version: '6.6'
-          - model: OP-PAD-3
-            soc: sun
-            branch: oneplus/sm8750
-            manifest: oneplus_pad_3.xml
-            android_version: android15
-            kernel_version: '6.6'
-#          - model: OP13T
-#            soc: sun
-#            branch: oneplus/sm8750
-#            manifest: oneplus_13t.xml
-#            android_version: android15
-#            kernel_version: '6.6'
-#          - model: OP-PAD-2-PRO
-#            soc: sun
-#            branch: oneplus/sm8750
-#            manifest: oneplus_pad_2_pro.xml
-#            android_version: android15
-#            kernel_version: '6.6'
-          
-    runs-on: [self-hosted, ubuntu-24.04]
+        # batch-1
+        - model: OP11
+          soc: kalama
+          branch: oneplus/sm8550
+          manifest: oneplus_11_v.xml
+          android_version: android13
+          kernel_version: '5.15'
+        - model: OP13-CN
+          soc: sun
+          branch: oneplus/sm8750
+          manifest: oneplus_13.xml
+          android_version: android15
+          kernel_version: '6.6'
+        - model: OP13-GLO
+          soc: sun
+          branch: oneplus/sm8750
+          manifest: oneplus_13_global.xml
+          android_version: android15
+          kernel_version: '6.6'
+#        - model: OPAce5Pro
+#          soc: sun
+#          branch: oneplus/sm8750
+#          manifest: oneplus_ace5_pro.xml
+#          android_version: android15
+#          kernel_version: '6.6'
+        - model: OP13S
+          soc: sun
+          branch: oneplus/sm8750
+          manifest: oneplus_13s.xml
+          android_version: android15
+          kernel_version: '6.6'
+        - model: OP-PAD-3
+          soc: sun
+          branch: oneplus/sm8750
+          manifest: oneplus_pad_3.xml
+          android_version: android15
+          kernel_version: '6.6'
+#        - model: OP13T
+#          soc: sun
+#          branch: oneplus/sm8750
+#          manifest: oneplus_13t.xml
+#          android_version: android15
+#          kernel_version: '6.6'
+#        - model: OP-PAD-2-PRO
+#          soc: sun
+#          branch: oneplus/sm8750
+#          manifest: oneplus_pad_2_pro.xml
+#          android_version: android15
+#          kernel_version: '6.6'
+        # batch-2
+        - model: OP12
+          soc: pineapple
+          branch: oneplus/sm8650
+          manifest: oneplus12_v.xml
+          android_version: android14
+          kernel_version: '6.1'
+        - model: OP13r
+          soc: pineapple
+          branch: oneplus/sm8650
+          manifest: oneplus_13r.xml
+          android_version: android14
+          kernel_version: '6.1'
+#        - model: OP-ACE-5
+#          soc: pineapple
+#          branch: oneplus/sm8650
+#          manifest: oneplus_ace5.xml
+#          android_version: android14
+#          kernel_version: '6.1'
+#        - model: OP-ACE-3V
+#          soc: pineapple
+#          branch: oneplus/sm7675
+#          manifest: oneplus_ace_3v_v.xml
+#          android_version: android14
+#          kernel_version: '6.1'
+        - model: OP-NORD-4
+          soc: pineapple
+          branch: oneplus/sm7675
+          manifest: oneplus_nord_4_v.xml
+          android_version: android14
+          kernel_version: '6.1'
+        - model: OP-Nord-5
+          soc: cliffs
+          branch: oneplus/sm8635
+          manifest: oneplus_nord_5.xml
+          android_version: android14
+          kernel_version: '6.1'
+        - model: OP-PAD-2
+          soc: pineapple
+          branch: oneplus/sm8650
+          manifest: oneplus_pad2_v.xml
+          android_version: android14
+          kernel_version: '6.1'
+#        - model: OP-Ace3-Pro
+#          soc: pineapple
+#          branch: oneplus/sm8650
+#          manifest: oneplus_ace3_pro_v.xml
+#          android_version: android14
+#          kernel_version: '6.1'
+        - model: OP-Nord-CE4-LITE
+          soc: blair
+          branch: oneplus/sm6375
+          manifest: oneplus_nord_ce4_lite_5g_v.xml
+          android_version: android14
+          kernel_version: '6.1'
+#        - model: OP-PAD-Pro
+#          soc: pineapple
+#          branch: oneplus/sm8650
+#          manifest: oneplus_pad_pro_v.xml
+#          android_version: android14
+#          kernel_version: '6.1'
+        # batch-3
+        - model: OP11r
+          soc: waipio
+          branch: oneplus/sm8475
+          manifest: oneplus_11r_v.xml
+          android_version: android12
+          kernel_version: '5.10'
+        - model: OP-OPEN
+          soc: kalama
+          branch: oneplus/sm8550
+          manifest: oneplus_open_v.xml
+          android_version: android13
+          kernel_version: '5.15'
+#        - model: OP-ACE-2
+#          soc: waipio
+#          branch: oneplus/sm8475
+#          manifest: oneplus_ace2_v.xml
+#          android_version: android12
+#          kernel_version: '5.10'
+        - model: OP10t
+          soc: waipio
+          branch: oneplus/sm8475
+          manifest: oneplus_10t_v.xml
+          android_version: android12
+          kernel_version: '5.10'
+        - model: OP-Nord-4-CE
+          soc: crow
+          branch: oneplus/sm7550
+          manifest: oneplus_nord_ce4_v.xml
+          android_version: android13
+          kernel_version: '5.15'
+        - model: OP10pro
+          soc: waipio
+          branch: oneplus/sm8450
+          manifest: oneplus_10_pro_v.xml
+          android_version: android12
+          kernel_version: '5.10'
+#        - model: OP-ACE-2-PRO
+#          soc: kalama
+#          branch: oneplus/sm8550
+#          manifest: oneplus_ace2_pro_v.xml
+#          android_version: android13
+#          kernel_version: '5.15'
+        - model: OP12r
+          soc: kalama
+          branch: oneplus/sm8550
+          manifest: oneplus_12r_v.xml
+          android_version: android13
+          kernel_version: '5.15'
     steps:
-      - name: Select Appropriate SusFS Branch
-        id: get-susfs-branch
+      - name: Resolve SUSFS branch from inputs
+        id: susfs
+        shell: bash
         run: |
-          KERNEL_STRING="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
-          SUSFS_BRANCH=""
-          case "$KERNEL_STRING" in
-            "android12-5.10")
-              SUSFS_BRANCH="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.10")
-              SUSFS_BRANCH="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.15")
-              SUSFS_BRANCH="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-5.15")
-              SUSFS_BRANCH="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-6.1")
-              SUSFS_BRANCH="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
-              ;;
-            "android15-6.6")
-              SUSFS_BRANCH="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
-              ;;
-            *)
-              echo "Invalid kernel version or unsupported: $KERNEL_STRING"
-              exit 1
-              ;;
-          esac
-
-          echo "susfs_branch=$SUSFS_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          key="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
+          declare -A map=(
+            ["android12-5.10"]="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
+            ["android13-5.10"]="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
+            ["android13-5.15"]="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
+            ["android14-5.15"]="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
+            ["android14-6.1"]="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
+            ["android15-6.6"]="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
+          )
+          # Only validate mapping presence; allow empty string value to be passed through.
+          if [[ -z "${map[$key]+_exists}" ]]; then
+            echo "Unsupported combo (no mapping): $key" >&2
+            exit 1
+          fi
+          echo "susfs_branch=${map[$key]}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -153,241 +251,18 @@ jobs:
           branch: ${{ matrix.branch }}
           manifest: ${{ matrix.manifest }}
           ksun_branch: ${{ inputs.ksun_branch }}
-          susfs_commit_hash_or_branch: ${{ steps.get-susfs-branch.outputs.susfs_branch }}
-          optimize_level: ${{ inputs.optimize_level }}
-
-  build-batch-2:
-    name: build-batch-2 (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - model: OP12
-            soc: pineapple
-            branch: oneplus/sm8650
-            manifest: oneplus12_v.xml
-            android_version: android14
-            kernel_version: '6.1'
-          - model: OP13r
-            soc: pineapple
-            branch: oneplus/sm8650
-            manifest: oneplus_13r.xml
-            android_version: android14
-            kernel_version: '6.1'
-#          - model: OP-ACE-5
-#            soc: pineapple
-#            branch: oneplus/sm8650
-#            manifest: oneplus_ace5.xml
-#            android_version: android14
-#            kernel_version: '6.1'
-#          - model: OP-ACE-3V
-#            soc: pineapple
-#            branch: oneplus/sm7675
-#            manifest: oneplus_ace_3v_v.xml
-#            android_version: android14
-#            kernel_version: '6.1'
-          - model: OP-NORD-4
-            soc: pineapple
-            branch: oneplus/sm7675
-            manifest: oneplus_nord_4_v.xml
-            android_version: android14
-            kernel_version: '6.1'
-          - model: OP-Nord-5
-            soc: cliffs
-            branch: oneplus/sm8635
-            manifest: oneplus_nord_5.xml
-            android_version: android14
-            kernel_version: "6.1"
-          - model: OP-PAD-2
-            soc: pineapple
-            branch: oneplus/sm8650
-            manifest: oneplus_pad2_v.xml
-            android_version: android14
-            kernel_version: '6.1'
-#          - model: OP-Ace3-Pro
-#            soc: pineapple
-#            branch: oneplus/sm8650
-#            manifest: oneplus_ace3_pro_v.xml
-#            android_version: android14
-#            kernel_version: '6.1'
-          - model: OP-Nord-CE4-LITE
-            soc: blair
-            branch: oneplus/sm6375
-            manifest: oneplus_nord_ce4_lite_5g_v.xml
-            android_version: android14
-            kernel_version: "6.1"
-#          - model: OP-PAD-Pro
-#            soc: pineapple
-#            branch: oneplus/sm8650
-#            manifest: oneplus_pad_pro_v.xml
-#            android_version: android14
-#            kernel_version: '6.1'
-    runs-on: [self-hosted, ubuntu-24.04]
-    steps:
-      - name: Select Appropriate SusFS Branch
-        id: get-susfs-branch
-        run: |
-          KERNEL_STRING="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
-          SUSFS_BRANCH=""
-          case "$KERNEL_STRING" in
-            "android12-5.10")
-              SUSFS_BRANCH="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.10")
-              SUSFS_BRANCH="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.15")
-              SUSFS_BRANCH="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-5.15")
-              SUSFS_BRANCH="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-6.1")
-              SUSFS_BRANCH="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
-              ;;
-            "android15-6.6")
-              SUSFS_BRANCH="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
-              ;;
-            *)
-              echo "Invalid kernel version or unsupported: $KERNEL_STRING"
-              exit 1
-              ;;
-          esac
-          
-          echo "susfs_branch=$SUSFS_BRANCH" >> $GITHUB_OUTPUT
-
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Build Kernel
-        uses: ./.github/actions
-        with:
-          model: ${{ matrix.model }}
-          soc: ${{ matrix.soc }}
-          branch: ${{ matrix.branch }}
-          manifest: ${{ matrix.manifest }}
-          ksun_branch: ${{ inputs.ksun_branch }}
-          susfs_commit_hash_or_branch: ${{ steps.get-susfs-branch.outputs.susfs_branch }}
-          optimize_level: ${{ inputs.optimize_level }}
-
-  build-batch-3:
-    name: build-batch-3 (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - model: OP11r
-            soc: waipio
-            branch: oneplus/sm8475
-            manifest: oneplus_11r_v.xml
-            android_version: android12
-            kernel_version: '5.10'
-          - model: OP-OPEN
-            soc: kalama
-            branch: oneplus/sm8550
-            manifest: oneplus_open_v.xml
-            android_version: android13
-            kernel_version: '5.15'
-#          - model: OP-ACE-2
-#            soc: waipio
-#            branch: oneplus/sm8475
-#            manifest: oneplus_ace2_v.xml
-#            android_version: android12
-#            kernel_version: '5.10'
-          - model: OP10t
-            soc: waipio
-            branch: oneplus/sm8475
-            manifest: oneplus_10t_v.xml
-            android_version: android12
-            kernel_version: '5.10'
-          - model: OP-Nord-4-CE
-            soc: crow
-            branch: oneplus/sm7550
-            manifest: oneplus_nord_ce4_v.xml
-            android_version: android13
-            kernel_version: "5.15"
-          - model: OP10pro
-            soc: waipio
-            branch: oneplus/sm8450
-            manifest: oneplus_10_pro_v.xml
-            android_version: android12
-            kernel_version: '5.10'
-#          - model: OP-ACE-2-PRO
-#            soc: kalama
-#            branch: oneplus/sm8550
-#            manifest: oneplus_ace2_pro_v.xml
-#            android_version: android13
-#            kernel_version: '5.15'
-          - model: OP12r
-            soc: kalama
-            branch: oneplus/sm8550
-            manifest: oneplus_12r_v.xml
-            android_version: android13
-            kernel_version: '5.15'          
-    runs-on: [self-hosted, ubuntu-24.04]
-    steps:
-      - name: Select Appropriate SusFS Branch
-        id: get-susfs-branch
-        run: |
-          KERNEL_STRING="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
-          SUSFS_BRANCH=""
-          case "$KERNEL_STRING" in
-            "android12-5.10")
-              SUSFS_BRANCH="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.10")
-              SUSFS_BRANCH="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.15")
-              SUSFS_BRANCH="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-5.15")
-              SUSFS_BRANCH="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-6.1")
-              SUSFS_BRANCH="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
-              ;;
-            "android15-6.6")
-              SUSFS_BRANCH="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
-              ;;
-            *)
-              echo "Invalid kernel version or unsupported: $KERNEL_STRING"
-              exit 1
-              ;;
-          esac
-          
-          echo "susfs_branch=$SUSFS_BRANCH" >> $GITHUB_OUTPUT
-
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Build Kernel
-        uses: ./.github/actions
-        with:
-          model: ${{ matrix.model }}
-          soc: ${{ matrix.soc }}
-          branch: ${{ matrix.branch }}
-          manifest: ${{ matrix.manifest }}
-          ksun_branch: ${{ inputs.ksun_branch }}
-          susfs_commit_hash_or_branch: ${{ steps.get-susfs-branch.outputs.susfs_branch }}
+          susfs_commit_hash_or_branch: ${{ steps.susfs.outputs.susfs_branch }}
           optimize_level: ${{ inputs.optimize_level }}
 
   trigger-release:
-    needs:
-      - build-batch-1
-      - build-batch-2
-      - build-batch-3
+    needs: [build]
     runs-on: [self-hosted, ubuntu-24.04]
     if: ${{ inputs.make_release }}
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASE_NAME: '*TEST BUILD* OnePlus Kernels With KernelSU Next & SUSFS v1.5.11 *TEST BUILD*'
+      RELEASE_NAME: '*TEST BUILD* OnePlus Kernels With KernelSU Next & SUSFS v1.5.12 *TEST BUILD*'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -396,7 +271,7 @@ jobs:
           
       - name: Generate and Create New Tag
         run: |
-          BASE_TAG="v1.5.11-r0"
+          BASE_TAG="v1.5.12-r0"
           LATEST_TAG=$(gh api repos/$REPO_OWNER/$REPO_NAME/tags --jq '.[0].name')
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="$BASE_TAG"
@@ -419,7 +294,7 @@ jobs:
         run: |
           echo "=== Start building the release notes ==="
           cat << EOF > release_notes.md
-          This release contains KernelSU Next and SUSFS v1.5.11
+          This release contains KernelSU Next and SUSFS v1.5.12
           
           Module: 
           -> https://github.com/sidex15/ksu_module_susfs  
@@ -450,7 +325,7 @@ jobs:
           
           ### Features
           - [+] KernelSU-Next / WildKSU Manager Support
-          - [+] SUSFS v1.5.11
+          - [+] SUSFS v1.5.12
           - [+] Wireguard Support
           - [+] Magic Mount Support
           - [+] Ptrace message leak fix for kernels < 5.16
@@ -459,6 +334,7 @@ jobs:
           - [+] BBR v1 Support
           - [+] HMBIRD scx support for OnePlus 13
           - [+] Baseband Guard Support (BBG).
+          - [+] xx_maps hide.
           EOF
           
           # Output for debugging

--- a/.github/workflows/op10pro.yml
+++ b/.github/workflows/op10pro.yml
@@ -21,9 +21,7 @@ on:
         description: "Compiler optimization level"
         required: true
         type: choice
-        options:
-          - O2
-          - O3
+        options: [O2, O3]
         default: O2
       android12-5_10_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android12-5.10'
@@ -51,57 +49,46 @@ on:
         default: ''
 
 jobs:
-  build-batch:
-    name: build-batch (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+  build:
+    name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+    
+    runs-on: [self-hosted, ubuntu-24.04]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - model: OP10pro
-            soc: waipio
-            branch: oneplus/sm8450
-            manifest: oneplus_10_pro_v.xml
-            android_version: android12
-            kernel_version: '5.10'
-          
-    runs-on: [self-hosted, ubuntu-24.04]
+        - model: OP10pro
+          soc: waipio
+          branch: oneplus/sm8450
+          manifest: oneplus_10_pro_v.xml
+          android_version: android12
+          kernel_version: '5.10'
     steps:
-      - name: Select Appropriate SusFS Branch
-        id: get-susfs-branch
+      - name: Resolve SUSFS branch from inputs
+        id: susfs
+        shell: bash
         run: |
-          KERNEL_STRING="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
-          SUSFS_BRANCH=""
-          case "$KERNEL_STRING" in
-            "android12-5.10")
-              SUSFS_BRANCH="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.10")
-              SUSFS_BRANCH="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.15")
-              SUSFS_BRANCH="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-5.15")
-              SUSFS_BRANCH="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-6.1")
-              SUSFS_BRANCH="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
-              ;;
-            "android15-6.6")
-              SUSFS_BRANCH="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
-              ;;
-            *)
-              echo "Invalid kernel version or unsupported: $KERNEL_STRING"
-              exit 1
-              ;;
-          esac
-
-          echo "susfs_branch=$SUSFS_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          key="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
+          declare -A map=(
+            ["android12-5.10"]="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
+            ["android13-5.10"]="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
+            ["android13-5.15"]="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
+            ["android14-5.15"]="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
+            ["android14-6.1"]="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
+            ["android15-6.6"]="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
+          )
+          # Only validate mapping presence; allow empty string value to be passed through.
+          if [[ -z "${map[$key]+_exists}" ]]; then
+            echo "Unsupported combo (no mapping): $key" >&2
+            exit 1
+          fi
+          echo "susfs_branch=${map[$key]}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Build Kernel
         uses: ./.github/actions
@@ -111,19 +98,18 @@ jobs:
           branch: ${{ matrix.branch }}
           manifest: ${{ matrix.manifest }}
           ksun_branch: ${{ inputs.ksun_branch }}
-          susfs_commit_hash_or_branch: ${{ steps.get-susfs-branch.outputs.susfs_branch }}
+          susfs_commit_hash_or_branch: ${{ steps.susfs.outputs.susfs_branch }}
           optimize_level: ${{ inputs.optimize_level }}
 
   trigger-release:
-    needs:
-      - build-batch
+    needs: [build]
     runs-on: [self-hosted, ubuntu-24.04]
     if: ${{ inputs.make_release }}
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASE_NAME: '*TEST BUILD* OnePlus 10 Pro Kernel With KernelSU Next & SUSFS v1.5.11 *TEST BUILD*'
+      RELEASE_NAME: '*TEST BUILD* OnePlus 10 Pro Kernel With KernelSU Next & SUSFS v1.5.12 *TEST BUILD*'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,7 +118,7 @@ jobs:
           
       - name: Generate and Create New Tag
         run: |
-          BASE_TAG="v1.5.11-r0"
+          BASE_TAG="v1.5.12-r0"
           LATEST_TAG=$(gh api repos/$REPO_OWNER/$REPO_NAME/tags --jq '.[0].name')
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="$BASE_TAG"
@@ -155,13 +141,16 @@ jobs:
         run: |
           echo "=== Start building the release notes ==="
           cat << EOF > release_notes.md
-          This release contains KernelSU Next and SUSFS v1.5.11
+          This release contains KernelSU Next and SUSFS v1.5.12
           
           Module: 
           -> https://github.com/sidex15/ksu_module_susfs  
           
-          Non-Official Managers:
+          Official Managers:
           -> https://github.com/KernelSU-Next/KernelSU-Next  
+          
+          Non-Official Managers:
+          -> https://github.com/WildKernels/Wild_KSU
           
           ### Built Devices
           
@@ -182,11 +171,9 @@ jobs:
           cat << 'EOF' >> release_notes.md
           
           ### Features
-          - [+] KernelSU-Next
-          - [+] SUSFS v1.5.11
+          - [+] KernelSU-Next / WildKSU Manager Support
+          - [+] SUSFS v1.5.12
           - [+] Wireguard Support
-          - [+] Maphide LineageOS Detections
-          - [+] Futile Maphide for jit-zygote-cache Detections
           - [+] Magic Mount Support
           - [+] Ptrace message leak fix for kernels < 5.16
           - [+] Manual Hooks [scope_min_manual_hooks_v1.4]
@@ -194,6 +181,7 @@ jobs:
           - [+] BBR v1 Support
           - [+] HMBIRD scx support for OnePlus 13
           - [+] Baseband Guard Support (BBG).
+          - [+] xx_maps hide.
           EOF
           
           # Output for debugging

--- a/.github/workflows/op13-cn.yml
+++ b/.github/workflows/op13-cn.yml
@@ -21,9 +21,7 @@ on:
         description: "Compiler optimization level"
         required: true
         type: choice
-        options:
-          - O2
-          - O3
+        options: [O2, O3]
         default: O2
       android12-5_10_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android12-5.10'
@@ -51,57 +49,46 @@ on:
         default: ''
 
 jobs:
-  build-batch:
-    name: build-batch (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+  build:
+    name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+    
+    runs-on: [self-hosted, ubuntu-24.04]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - model: OP13-CN
-            soc: sun
-            branch: oneplus/sm8750
-            manifest: oneplus_13.xml
-            android_version: android15
-            kernel_version: '6.6'
-          
-    runs-on: [self-hosted, ubuntu-24.04]
+        - model: OP13-CN
+          soc: sun
+          branch: oneplus/sm8750
+          manifest: oneplus_13.xml
+          android_version: android15
+          kernel_version: '6.6'
     steps:
-      - name: Select Appropriate SusFS Branch
-        id: get-susfs-branch
+      - name: Resolve SUSFS branch from inputs
+        id: susfs
+        shell: bash
         run: |
-          KERNEL_STRING="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
-          SUSFS_BRANCH=""
-          case "$KERNEL_STRING" in
-            "android12-5.10")
-              SUSFS_BRANCH="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.10")
-              SUSFS_BRANCH="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.15")
-              SUSFS_BRANCH="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-5.15")
-              SUSFS_BRANCH="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-6.1")
-              SUSFS_BRANCH="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
-              ;;
-            "android15-6.6")
-              SUSFS_BRANCH="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
-              ;;
-            *)
-              echo "Invalid kernel version or unsupported: $KERNEL_STRING"
-              exit 1
-              ;;
-          esac
-
-          echo "susfs_branch=$SUSFS_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          key="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
+          declare -A map=(
+            ["android12-5.10"]="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
+            ["android13-5.10"]="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
+            ["android13-5.15"]="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
+            ["android14-5.15"]="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
+            ["android14-6.1"]="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
+            ["android15-6.6"]="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
+          )
+          # Only validate mapping presence; allow empty string value to be passed through.
+          if [[ -z "${map[$key]+_exists}" ]]; then
+            echo "Unsupported combo (no mapping): $key" >&2
+            exit 1
+          fi
+          echo "susfs_branch=${map[$key]}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Build Kernel
         uses: ./.github/actions
@@ -111,19 +98,18 @@ jobs:
           branch: ${{ matrix.branch }}
           manifest: ${{ matrix.manifest }}
           ksun_branch: ${{ inputs.ksun_branch }}
-          susfs_commit_hash_or_branch: ${{ steps.get-susfs-branch.outputs.susfs_branch }}
+          susfs_commit_hash_or_branch: ${{ steps.susfs.outputs.susfs_branch }}
           optimize_level: ${{ inputs.optimize_level }}
 
   trigger-release:
-    needs:
-      - build-batch
+    needs: [build]
     runs-on: [self-hosted, ubuntu-24.04]
     if: ${{ inputs.make_release }}
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASE_NAME: '*TEST BUILD* OnePlus 13 CN Kernel With KernelSU Next & SUSFS v1.5.11 *TEST BUILD*'
+      RELEASE_NAME: '*TEST BUILD* OnePlus 13 CN Kernel With KernelSU Next & SUSFS v1.5.12 *TEST BUILD*'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,7 +118,7 @@ jobs:
           
       - name: Generate and Create New Tag
         run: |
-          BASE_TAG="v1.5.11-r0"
+          BASE_TAG="v1.5.12-r0"
           LATEST_TAG=$(gh api repos/$REPO_OWNER/$REPO_NAME/tags --jq '.[0].name')
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="$BASE_TAG"
@@ -155,13 +141,16 @@ jobs:
         run: |
           echo "=== Start building the release notes ==="
           cat << EOF > release_notes.md
-          This release contains KernelSU Next and SUSFS v1.5.11
+          This release contains KernelSU Next and SUSFS v1.5.12
           
           Module: 
           -> https://github.com/sidex15/ksu_module_susfs  
           
-          Non-Official Managers:
+          Official Managers:
           -> https://github.com/KernelSU-Next/KernelSU-Next  
+          
+          Non-Official Managers:
+          -> https://github.com/WildKernels/Wild_KSU
           
           ### Built Devices
           
@@ -182,11 +171,9 @@ jobs:
           cat << 'EOF' >> release_notes.md
           
           ### Features
-          - [+] KernelSU-Next
-          - [+] SUSFS v1.5.11
+          - [+] KernelSU-Next / WildKSU Manager Support
+          - [+] SUSFS v1.5.12
           - [+] Wireguard Support
-          - [+] Maphide LineageOS Detections
-          - [+] Futile Maphide for jit-zygote-cache Detections
           - [+] Magic Mount Support
           - [+] Ptrace message leak fix for kernels < 5.16
           - [+] Manual Hooks [scope_min_manual_hooks_v1.4]
@@ -194,6 +181,7 @@ jobs:
           - [+] BBR v1 Support
           - [+] HMBIRD scx support for OnePlus 13
           - [+] Baseband Guard Support (BBG).
+          - [+] xx_maps hide.
           EOF
           
           # Output for debugging

--- a/.github/workflows/op13-glo.yml
+++ b/.github/workflows/op13-glo.yml
@@ -21,9 +21,7 @@ on:
         description: "Compiler optimization level"
         required: true
         type: choice
-        options:
-          - O2
-          - O3
+        options: [O2, O3]
         default: O2
       android12-5_10_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android12-5.10'
@@ -51,57 +49,46 @@ on:
         default: ''
 
 jobs:
-  build-batch:
-    name: build-batch (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+  build:
+    name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
+    
+    runs-on: [self-hosted, ubuntu-24.04]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - model: OP13-GLO
-            soc: sun
-            branch: oneplus/sm8750
-            manifest: oneplus_13_global.xml
-            android_version: android15
-            kernel_version: '6.6'
-          
-    runs-on: [self-hosted, ubuntu-24.04]
+        - model: OP13-GLO
+          soc: sun
+          branch: oneplus/sm8750
+          manifest: oneplus_13_global.xml
+          android_version: android15
+          kernel_version: '6.6'
     steps:
-      - name: Select Appropriate SusFS Branch
-        id: get-susfs-branch
+      - name: Resolve SUSFS branch from inputs
+        id: susfs
+        shell: bash
         run: |
-          KERNEL_STRING="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
-          SUSFS_BRANCH=""
-          case "$KERNEL_STRING" in
-            "android12-5.10")
-              SUSFS_BRANCH="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.10")
-              SUSFS_BRANCH="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
-              ;;
-            "android13-5.15")
-              SUSFS_BRANCH="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-5.15")
-              SUSFS_BRANCH="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
-              ;;
-            "android14-6.1")
-              SUSFS_BRANCH="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
-              ;;
-            "android15-6.6")
-              SUSFS_BRANCH="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
-              ;;
-            *)
-              echo "Invalid kernel version or unsupported: $KERNEL_STRING"
-              exit 1
-              ;;
-          esac
-
-          echo "susfs_branch=$SUSFS_BRANCH" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          key="${{ matrix.android_version }}-${{ matrix.kernel_version }}"
+          declare -A map=(
+            ["android12-5.10"]="${{ inputs.android12-5_10_susfs_branch_or_commit }}"
+            ["android13-5.10"]="${{ inputs.android13-5_10_susfs_branch_or_commit }}"
+            ["android13-5.15"]="${{ inputs.android13-5_15_susfs_branch_or_commit }}"
+            ["android14-5.15"]="${{ inputs.android14-5_15_susfs_branch_or_commit }}"
+            ["android14-6.1"]="${{ inputs.android14-6_1_susfs_branch_or_commit }}"
+            ["android15-6.6"]="${{ inputs.android15-6_6_susfs_branch_or_commit }}"
+          )
+          # Only validate mapping presence; allow empty string value to be passed through.
+          if [[ -z "${map[$key]+_exists}" ]]; then
+            echo "Unsupported combo (no mapping): $key" >&2
+            exit 1
+          fi
+          echo "susfs_branch=${map[$key]}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Build Kernel
         uses: ./.github/actions
@@ -111,19 +98,18 @@ jobs:
           branch: ${{ matrix.branch }}
           manifest: ${{ matrix.manifest }}
           ksun_branch: ${{ inputs.ksun_branch }}
-          susfs_commit_hash_or_branch: ${{ steps.get-susfs-branch.outputs.susfs_branch }}
+          susfs_commit_hash_or_branch: ${{ steps.susfs.outputs.susfs_branch }}
           optimize_level: ${{ inputs.optimize_level }}
 
   trigger-release:
-    needs:
-      - build-batch
+    needs: [build]
     runs-on: [self-hosted, ubuntu-24.04]
     if: ${{ inputs.make_release }}
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASE_NAME: '*TEST BUILD* OnePlus 13 GLO Kernel With KernelSU Next & SUSFS v1.5.11 *TEST BUILD*'
+      RELEASE_NAME: '*TEST BUILD* OnePlus 13 GLO Kernel With KernelSU Next & SUSFS v1.5.12 *TEST BUILD*'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,7 +118,7 @@ jobs:
           
       - name: Generate and Create New Tag
         run: |
-          BASE_TAG="v1.5.11-r0"
+          BASE_TAG="v1.5.12-r0"
           LATEST_TAG=$(gh api repos/$REPO_OWNER/$REPO_NAME/tags --jq '.[0].name')
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="$BASE_TAG"
@@ -155,13 +141,16 @@ jobs:
         run: |
           echo "=== Start building the release notes ==="
           cat << EOF > release_notes.md
-          This release contains KernelSU Next and SUSFS v1.5.11
+          This release contains KernelSU Next and SUSFS v1.5.12
           
           Module: 
           -> https://github.com/sidex15/ksu_module_susfs  
           
-          Non-Official Managers:
+          Official Managers:
           -> https://github.com/KernelSU-Next/KernelSU-Next  
+          
+          Non-Official Managers:
+          -> https://github.com/WildKernels/Wild_KSU
           
           ### Built Devices
           
@@ -182,11 +171,9 @@ jobs:
           cat << 'EOF' >> release_notes.md
           
           ### Features
-          - [+] KernelSU-Next
-          - [+] SUSFS v1.5.11
+          - [+] KernelSU-Next / WildKSU Manager Support
+          - [+] SUSFS v1.5.12
           - [+] Wireguard Support
-          - [+] Maphide LineageOS Detections
-          - [+] Futile Maphide for jit-zygote-cache Detections
           - [+] Magic Mount Support
           - [+] Ptrace message leak fix for kernels < 5.16
           - [+] Manual Hooks [scope_min_manual_hooks_v1.4]
@@ -194,6 +181,7 @@ jobs:
           - [+] BBR v1 Support
           - [+] HMBIRD scx support for OnePlus 13
           - [+] Baseband Guard Support (BBG).
+          - [+] xx_maps hide.
           EOF
           
           # Output for debugging


### PR DESCRIPTION
Refines the build summary to display the precise Git commit SHA for KernelSU-Next and SUSFS instead of the input branch name or default.